### PR TITLE
docs: チーム情報とデモ/プレゼン資料ないの項目を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 ## チーム情報
 - チーム番号: 7
-- チーム名: KUT
-- プロダクト名: （ここに記入）
+- チーム名: 灰コーダー
+- プロダクト名: Study Time Tracker
 - メンバー: 佐藤謙成，丸山祐樹，岩村萌花，山本翔
 
 ---
 
 ## デモ　/ プレゼン資料
-- デモURL: 
-- プレゼンURL：
+- デモURL: https://drive.google.com/file/d/1FVbMatyW38sEEL039BSwYH-BhRMatWs3/view?usp=sharing
+- プレゼンURL：https://docs.google.com/presentation/d/1yzT1qHAX7waUtxVA_TBrVs6MdA33-59EwOcXr_CyntQ/edit?usp=sharing


### PR DESCRIPTION
チーム名、プロダクト名、デモ・プレゼンURLの項目を追記しました。